### PR TITLE
WIP events and calbacks

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -1,0 +1,26 @@
+package vlc
+
+//#cgo LDFLAGS: -lvlc
+//#include <stdlib.h>
+//#include <stdio.h>
+//#include <vlc/vlc.h>
+//typedef const struct libvlc_event_t clibvlc_event_t;
+import "C"
+import "unsafe"
+
+//export goCallback
+func goCallback(e *C.clibvlc_event_t, userData unsafe.Pointer) {
+	token := *(*int)(userData)
+
+	handleLock.Lock()
+	ectx := handleMap[token]
+	handleLock.Unlock()
+
+	event := &Event{
+		Type:   EventType(e._type),
+		target: nil, // TODO
+	}
+	// event.desc.Write(e.u[:])
+
+	ectx.call(event, ectx.userData)
+}

--- a/event.go
+++ b/event.go
@@ -1,5 +1,14 @@
 package vlc
 
+// #cgo LDFLAGS: -lvlc
+// #include <vlc/vlc.h>
+// #include <stdlib.h>
+import "C"
+import (
+	"bytes"
+	"encoding/binary"
+)
+
 type EventType uint16
 
 // Event types
@@ -70,7 +79,7 @@ const (
 const (
 
 	// Deprected
-	MediaDiscovererStarted = iota + ox500
+	MediaDiscovererStarted = iota + 0x500
 	MediaDiscovererEnded
 
 	RendererDiscovererItemAdded
@@ -78,7 +87,7 @@ const (
 )
 
 const (
-	VlmMediaAdded = iota + ox600
+	VlmMediaAdded = iota + 0x600
 	VlmMediaRemoved
 	VlmMediaChanged
 	VlmMediaInstanceStarted
@@ -90,3 +99,27 @@ const (
 	VlmMediaInstanceStatusEnd
 	VlmMediaInstanceStatusError
 )
+
+type Event struct {
+	Type   EventType     // Event type
+	target interface{}   // object emitting the event
+	desc   *bytes.Buffer // event descriptor
+}
+
+func (event *Event) MediaPlayerStopped() MediaState {
+	var i uint8
+	if err := binary.Write(event.desc, binary.LittleEndian, i); err != nil {
+		panic(err)
+	}
+
+	return MediaState(i)
+}
+
+func (event *Event) MediaPlayerPaused() MediaState {
+	var i uint8
+	if err := binary.Write(event.desc, binary.LittleEndian, i); err != nil {
+		panic(err)
+	}
+
+	return MediaState(i)
+}

--- a/event_manager.go
+++ b/event_manager.go
@@ -1,0 +1,67 @@
+package vlc
+
+//#cgo LDFLAGS: -lvlc
+//#include <stdlib.h>
+//#include <stdio.h>
+//#include <vlc/vlc.h>
+//typedef const struct libvlc_event_t clibvlc_event_t;
+//extern void goCallback(clibvlc_event_t*, void*);
+//static inline int goAttach(libvlc_event_manager_t* em, libvlc_event_type_t et, void* userData) {
+//    return libvlc_event_attach(em, et, goCallback, userData);
+//}
+import "C"
+
+import (
+	"log"
+	"sync"
+	"unsafe"
+)
+
+type Callback func(*Event, interface{})
+
+type eventContext struct {
+	token    int
+	et       C.libvlc_event_type_t
+	call     Callback
+	userData interface{}
+}
+
+var (
+	handleLock  sync.Mutex
+	handleToken int
+	handleMap   = make(map[int]*eventContext)
+)
+
+type EventManager struct {
+	event_manager *C.libvlc_event_manager_t
+}
+
+func NewEventManager(event_manager *C.libvlc_event_manager_t) *EventManager {
+	return &EventManager{
+		event_manager: event_manager,
+	}
+}
+
+func (em *EventManager) Attach(eventType EventType, callback Callback, userData interface{}) (int, error) {
+	ectx := &eventContext{
+		et:       C.libvlc_event_type_t(eventType),
+		call:     callback,
+		userData: userData,
+	}
+	handleLock.Lock()
+	handleToken++
+	ectx.token = handleToken
+	handleMap[ectx.token] = ectx
+	handleLock.Unlock()
+
+	if C.goAttach(em.event_manager, ectx.et, unsafe.Pointer(&handleToken)) != 0 {
+		log.Fatal("TODO")
+	}
+
+	return ectx.token, nil
+}
+
+func (em *EventManager) Dettach(eventType EventType, callback Callback, userData interface{}) (uintptr, error) {
+	log.Fatal("TODO")
+	return 0, nil
+}

--- a/event_type.go
+++ b/event_type.go
@@ -1,0 +1,92 @@
+package vlc
+
+type EventType uint16
+
+// Event types
+const (
+	MediaMetaChanged EventType = iota
+	MediaSubItemAdded
+	MediaDurationChanged
+	MediaParsedChanged
+	MediaFreed
+	MediaStateChanged
+	MediaSubItemTreeAdded
+)
+
+const (
+	MediaPlayerMediaChanged = iota + 0x100
+	MediaPlayerNothingSpecial
+	MediaPlayerOpening
+	MediaPlayerBuffering
+	MediaPlayerPlaying
+	MediaPlayerPaused
+	MediaPlayerStopped
+	MediaPlayerForward
+	MediaPlayerBackward
+	MediaPlayerEndReached
+	MediaPlayerEncounteredError
+	MediaPlayerTimeChanged
+	MediaPlayerPositionChanged
+	MediaPlayerSeekableChanged
+	MediaPlayerPausableChanged
+	MediaPlayerTitleChanged
+	MediaPlayerSnapshotTaken
+	MediaPlayerLengthChanged
+	MediaPlayerVout
+	MediaPlayerScrambledChanged
+	MediaPlayerESAdded
+	MediaPlayerESDeleted
+	MediaPlayerESSelected
+	MediaPlayerCorked
+	MediaPlayerUncorked
+	MediaPlayerMuted
+	MediaPlayerUnmuted
+	MediaPlayerAudioVolume
+	MediaPlayerAudioDevice
+	MediaPlayerChapterChanged
+)
+
+const (
+	MediaListItemAdded = iota + 0x200
+	MediaListWillAddItem
+	MediaListItemDeleted
+	MediaListWillDeleteItem
+	MediaListEndReached
+)
+
+const (
+	MediaListViewItemAdded = iota + 0x300
+	MediaListViewWillAddItem
+	MediaListViewItemDeleted
+	MediaListViewWillDeleteItem
+)
+
+const (
+	MediaListPlayerPlayed = iota + 0x400
+	MediaListPlayerNextItemSet
+	MediaListPlayerStopped
+)
+
+const (
+
+	// Deprected
+	MediaDiscovererStarted = iota + ox500
+	MediaDiscovererEnded
+
+	RendererDiscovererItemAdded
+	RendererDiscovererItemDeleted
+)
+
+const (
+	VlmMediaAdded = iota + ox600
+	VlmMediaRemoved
+	VlmMediaChanged
+	VlmMediaInstanceStarted
+	VlmMediaInstanceStopped
+	VlmMediaInstanceStatusInit
+	VlmMediaInstanceStatusOpening
+	VlmMediaInstanceStatusPlaying
+	VlmMediaInstanceStatusPause
+	VlmMediaInstanceStatusEnd
+	VlmMediaInstanceStatusError
+)

--- a/example/main.go
+++ b/example/main.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"log"
+	"time"
+
+	vlc "github.com/tarrsalah/libvlc-go"
+)
+
+func main() {
+	// Initialize libvlc. Additional command line arguments can be passed in
+	// to libvlc by specifying them in the Init function.
+	if err := vlc.Init("--quiet"); err != nil {
+		log.Fatal(err)
+	}
+	defer vlc.Release()
+
+	// Create a new player
+	player, err := vlc.NewPlayer()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() {
+		player.Stop()
+		player.Release()
+	}()
+
+	// Add a media file from path or from URL.
+	// Set player media from path:
+	// media, err := player.LoadMediaFromPath("localpath/test.mp4")
+	// Set player media from URL:
+	media, err := player.LoadMediaFromPath("./sample.mp4")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer media.Release()
+
+	// Play
+	err = player.Play()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Wait some amount of time for the media to start playing.
+	// Depends on the version of libvlc. From my tests, libvlc 3.X does not
+	// need this delay.
+	// TODO: Implement proper callbacks for getting the state of the media.
+	time.Sleep(1 * time.Second)
+
+	eventManager, err := player.EventManager()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	callback := func(event *vlc.Event, userData interface{}) {
+		log.Println(userData)
+	}
+	eventManager.Attach(vlc.MediaPlayerPaused, callback, "userData passed to the callback")
+	time.Sleep(2 * time.Second)
+	player.TogglePause()
+
+	// If the media played is a live stream the length will be 0
+	length, err := player.MediaLength()
+	if err != nil || length == 0 {
+		length = 1000 * 60
+	}
+
+	time.Sleep(time.Duration(length) * time.Millisecond)
+}

--- a/media.go
+++ b/media.go
@@ -9,7 +9,7 @@ import (
 	"unsafe"
 )
 
-type MediaState int
+type MediaState uint8
 
 const (
 	MediaIdle MediaState = iota

--- a/player.go
+++ b/player.go
@@ -287,3 +287,11 @@ func (p *Player) setMedia(m *Media) error {
 
 	return getError()
 }
+
+func (p *Player) EventManager() (*EventManager, error) {
+	if p.player == nil {
+		return nil, errors.New("A player must be initialized first")
+	}
+
+	return NewEventManager(C.libvlc_media_player_event_manager(p.player)), nil
+}


### PR DESCRIPTION
This is a **WIP** attempt to support the  [LibVLC asynchronous events](http://www.videolan.org/developers/vlc/doc/doxygen/html/group__libvlc__event.html), the work done in this PR is based on:

- [jteeuwen/go-vlc/](https://github.com/jteeuwen/go-vlc) implementation.
- [callback](https://golang.org/misc/cgo/test/callback.go) example.
- [cgo wiki](https://github.com/golang/go/wiki/cgo).

Please @adrg @fenimore,  I need code review in:
-  callbacks support in **cgo**.
-  Passing `C unions` back and forth between `C` and `go` (in the [libvlc_event_t ](http://www.videolan.org/developers/vlc/doc/doxygen/html/structlibvlc__event__t.html) type).

Best, 