### PR TITLE
Add GetMediaPlayer to list player to get underlying media player.

### DIFF
--- a/listplayer.go
+++ b/listplayer.go
@@ -49,6 +49,24 @@ func (lp *ListPlayer) Release() error {
 	return getError()
 }
 
+// MediaPlayer returns the underlying Player instance of the ListPlayer.
+func (lp *ListPlayer) MediaPlayer() (*Player, error) {
+	if lp.player == nil {
+		return nil, errors.New("A list player must be initialized first")
+	}
+
+	player := C.libvlc_media_list_player_get_media_player(lp.player)
+	if player == nil {
+		return nil, getError()
+	}
+
+	// This call will not release the player. Instead, it will decrement the
+	// reference count increased by libvlc_media_list_player_get_media_player.
+	C.libvlc_media_player_release(player)
+
+	return &Player{player: player}, nil
+}
+
 // Play plays the current media list.
 func (lp *ListPlayer) Play() error {
 	if lp.player == nil {
@@ -177,17 +195,4 @@ func (lp *ListPlayer) SetMediaList(ml *MediaList) error {
 	C.libvlc_media_list_player_set_media_list(lp.player, ml.list)
 
 	return getError()
-}
-
-// GetMediaPlayer returns the media player of the media list player instance
-func (lp *ListPlayer) GetMediaPlayer() (*Player, error) {
-	if lp.player == nil {
-		return nil, errors.New("A list player must be initialized first")
-	}
-
-	if player := C.libvlc_media_list_player_get_media_player(lp.player); player != nil {
-		return &Player{player: player}, nil
-	}
-
-	return nil, getError()
 }

--- a/listplayer.go
+++ b/listplayer.go
@@ -178,3 +178,16 @@ func (lp *ListPlayer) SetMediaList(ml *MediaList) error {
 
 	return getError()
 }
+
+// GetMediaPlayer returns the media player of the media list player instance
+func (lp *ListPlayer) GetMediaPlayer() (*Player, error) {
+	if lp.player == nil {
+		return nil, errors.New("A list player must be initialized first")
+	}
+
+	if player := C.libvlc_media_list_player_get_media_player(lp.player); player != nil {
+		return &Player{player: player}, nil
+	}
+
+	return nil, getError()
+}


### PR DESCRIPTION

Fixes #14 

Not sure if I missed anything, but with these changes I can now retrieve the underlying player from a list player and set it to fullscreen.


```
package main

import (
	"log"
	"time"

	vlc "github.com/adrg/libvlc-go"
)

func main() {
	// Initialize libvlc. Additional command line arguments can be passed in
	// to libvlc by specifying them in the Init function.
	if err := vlc.Init(); err != nil {
		log.Fatal(err)
	}
	defer vlc.Release()
	// Create a new list player
	player, err := vlc.NewListPlayer()
	if err != nil {
		log.Fatal(err)
	}
	defer func() {
		player.Stop()
		player.Release()
	}()

	// Create a new media list
	list, err := vlc.NewMediaList()
	if err != nil {
		log.Fatal(err)
	}
	defer list.Release()

	err = list.AddMediaFromPath("video2.mp4")
	if err != nil {
		log.Fatal(err)
	}

	err = list.AddMediaFromPath("video1.mp4")
	if err != nil {
		log.Fatal(err)
	}

	// Set player media list
	err = player.SetMediaList(list)
	if err != nil {
		log.Fatal(err)
	}

	// Play
	err = player.Play()
	if err != nil {
		log.Fatal(err)
	}

	underlyingPlayer, err := player.GetMediaPlayer()
	if err != nil {
		log.Fatal(err)
	}

	underlyingPlayer.SetFullScreen(true)

	time.Sleep(60 * 1000 * time.Millisecond)
}
```