### PR TITLE
Add wrapper for libvlc_media_player_set_xwindow

### DIFF
--- a/player.go
+++ b/player.go
@@ -304,6 +304,6 @@ func (p *Player) setXWindow(XID uint32) error {
 	if p.player == nil {
 		return errors.New("A player must be initialized first")
 	}
-	C.libvlc_media_player_set_xwindow(XID)
+	C.libvlc_media_player_set_xwindow(p.player, C.int(XID))
 	return getError()
 }

--- a/player.go
+++ b/player.go
@@ -299,3 +299,11 @@ func (p *Player) setMedia(m *Media) error {
 	C.libvlc_media_player_set_media(p.player, m.media)
 	return getError()
 }
+
+func (p *Player) setXWindow(uint32 XID) error {
+	if p.player == nil {
+		return errors.New("A player must be initialized first")
+	}
+	C.libvlc_media_player_set_xwindow(XID)
+	return getError()
+}

--- a/player.go
+++ b/player.go
@@ -300,7 +300,7 @@ func (p *Player) setMedia(m *Media) error {
 	return getError()
 }
 
-func (p *Player) setXWindow(uint32 XID) error {
+func (p *Player) setXWindow(XID uint32) error {
 	if p.player == nil {
 		return errors.New("A player must be initialized first")
 	}

--- a/player.go
+++ b/player.go
@@ -304,6 +304,6 @@ func (p *Player) setXWindow(XID uint32) error {
 	if p.player == nil {
 		return errors.New("A player must be initialized first")
 	}
-	C.libvlc_media_player_set_xwindow(p.player, C.int(XID))
+	C.libvlc_media_player_set_xwindow(p.player, C.uint(XID))
 	return getError()
 }

--- a/player.go
+++ b/player.go
@@ -300,11 +300,12 @@ func (p *Player) setMedia(m *Media) error {
 	return getError()
 }
 
-// SetXWindow sets the X window to play on
-func (p *Player) SetXWindow(XID uint32) error {
+// SetXWindow sets the X window to play on.
+func (p *Player) SetXWindow(windowID uint32) error {
 	if p.player == nil {
 		return errors.New("A player must be initialized first")
 	}
-	C.libvlc_media_player_set_xwindow(p.player, C.uint(XID))
+	
+	C.libvlc_media_player_set_xwindow(p.player, C.uint(windowID))
 	return getError()
 }

--- a/player.go
+++ b/player.go
@@ -300,7 +300,8 @@ func (p *Player) setMedia(m *Media) error {
 	return getError()
 }
 
-func (p *Player) setXWindow(XID uint32) error {
+// SetXWindow sets the X window to play on
+func (p *Player) SetXWindow(XID uint32) error {
 	if p.player == nil {
 		return errors.New("A player must be initialized first")
 	}


### PR DESCRIPTION
Tell the player which X window to draw in. Allows embedding libvlc media into X apps (in my case a GTK+ app.)

Tested in my application - movie played correctly.