### PR TITLE
Add support for events

### DIFF
--- a/eventmanager.go
+++ b/eventmanager.go
@@ -1,0 +1,105 @@
+package vlc
+
+//#cgo LDFLAGS: -lvlc
+//#include <stdlib.h>
+//#include <stdio.h>
+//#include <vlc/vlc.h>
+//typedef const struct libvlc_event_t *clibvlc_event_t;
+//extern void goCallback(clibvlc_event_t, void*);
+//static inline int goAttach(libvlc_event_manager_t* em, libvlc_event_type_t et, unsigned long userData) {
+//    return libvlc_event_attach(em, et, goCallback, (void *) userData);
+//}
+//static inline int goDetach(libvlc_event_manager_t* em, libvlc_event_type_t et, unsigned long userData) {
+//    libvlc_event_detach(em, et, goCallback, (void *) userData);
+//}
+import "C"
+
+import (
+	"reflect"
+	"sync"
+	"unsafe"
+)
+
+// EventCallback is the type of an event callback function.
+type EventCallback func(Event, interface{})
+
+type eventContext struct {
+	token    uint64
+	et       C.libvlc_event_type_t
+	call     EventCallback
+	userData interface{}
+}
+
+var (
+	eventRegistry = struct {
+		sync.RWMutex
+		nextToken uint64
+		contexts  map[uint64]*eventContext
+	}{
+		contexts: make(map[uint64]*eventContext),
+	}
+)
+
+// EventManager wraps a libvlc event manager.
+type EventManager struct {
+	Manager *C.libvlc_event_manager_t
+}
+
+// NewEventManager returns a new EventManager instance wrapping a libvlc manager.
+func NewEventManager(manager *C.libvlc_event_manager_t) *EventManager {
+	return &EventManager{
+		Manager: manager,
+	}
+}
+
+// Attach registers a callback for an event notification.
+func (em *EventManager) Attach(eventType Event, callback EventCallback, userData interface{}) (uint64, error) {
+	ectx := &eventContext{
+		et:       C.libvlc_event_type_t(eventType),
+		call:     callback,
+		userData: userData,
+	}
+	eventRegistry.Lock()
+	eventRegistry.nextToken++
+	ectx.token = eventRegistry.nextToken
+	eventRegistry.contexts[eventRegistry.nextToken] = ectx
+	eventRegistry.Unlock()
+
+	if C.goAttach(em.Manager, ectx.et, (C.ulong)(ectx.token)) != 0 {
+		return 0, getError()
+	}
+
+	return ectx.token, nil
+}
+
+// Detach unregisters an event notification.
+func (em *EventManager) Detach(eventType Event, callback EventCallback, userData interface{}) {
+	var ectx *eventContext
+
+	same := func(ctx *eventContext) bool {
+		return (ctx.et == C.libvlc_event_type_t(eventType) &&
+			reflect.DeepEqual(ctx.call, callback) && reflect.DeepEqual(ctx.userData, userData))
+	}
+
+	eventRegistry.Lock()
+	for token := range eventRegistry.contexts {
+		c := eventRegistry.contexts[token]
+		if same(c) {
+			// we have the listener
+			ectx = c
+			break
+		}
+	}
+	delete(eventRegistry.contexts, ectx.token)
+	eventRegistry.Unlock()
+
+	C.goDetach(em.Manager, ectx.et, (C.ulong)(ectx.token))
+
+}
+
+//export goCallback
+func goCallback(event C.clibvlc_event_t, userDataC unsafe.Pointer) {
+	userData := uint64(uintptr(userDataC))
+	ectx := eventRegistry.contexts[userData]
+	ectx.call(Event(event._type), ectx.userData)
+}

--- a/events.go
+++ b/events.go
@@ -1,7 +1,7 @@
 package vlc
 
 // Event represents an event that can occur inside libvlc.
-type Event uint
+type Event int
 
 // Media events.
 const (
@@ -28,12 +28,15 @@ const (
 	// MediaSubItemTreeAdded is triggered when a Subitem tree is
 	// added to a media item.
 	MediaSubItemTreeAdded
+
+	// MediaThumbnailGenerated is triggered when a thumbnail generation is completed.
+	MediaThumbnailGenerated
 )
 
 // Player events.
 const (
-	MediaPlayerMediaChanged Event = 0x100
-	MediaPlayerIdle
+	MediaPlayerMediaChanged Event = 0x100 + iota
+	MediaPlayerNothingSpecial
 	MediaPlayerOpening
 	MediaPlayerBuffering
 	MediaPlayerPlaying
@@ -67,7 +70,7 @@ const (
 // Media list events.
 const (
 	// MediaListItemAdded is triggered when a media item is added to a media list.
-	MediaListItemAdded Event = 0x200
+	MediaListItemAdded Event = 0x200 + iota
 
 	// MediaListWillAddItem is triggered when a media item is about to get
 	// added to a media list.
@@ -83,10 +86,12 @@ const (
 
 	// MediaListEndReached is triggered when a media list has reached the end.
 	MediaListEndReached
+)
 
+const (
 	// MediaListPlayerPlayed is triggered when Playback
 	// of a media list player has started.
-	MediaListPlayerPlayed = 0x400
+	MediaListPlayerPlayed = 0x400 + iota
 
 	// MediaListPlayerNextItemSet is triggered when the current item
 	// of a media list player has changed to a different item.
@@ -99,7 +104,7 @@ const (
 
 // Deprecated events.
 const (
-	MediaDiscovererStarted Event = 0x500
+	MediaDiscovererStarted Event = 0x500 + iota
 	MediaDiscovererEnded
 )
 
@@ -107,7 +112,7 @@ const (
 const (
 	// RendererDiscovererItemAdded is triggered when a new renderer item is
 	// found by a renderer discoverer. The renderer item is valid until deleted.
-	RendererDiscovererItemAdded Event = 0x502
+	RendererDiscovererItemAdded Event = 0x502 + iota
 
 	// RendererDiscovererItemDeleted is triggered when a previously discovered
 	// renderer item was deleted by a renderer discoverer. The renderer item
@@ -117,7 +122,7 @@ const (
 
 // VideoLAN Manager events.
 const (
-	VlmMediaAdded Event = 0x600
+	VlmMediaAdded Event = 0x600 + iota
 	VlmMediaRemoved
 	VlmMediaChanged
 	VlmMediaInstanceStarted

--- a/player.go
+++ b/player.go
@@ -284,6 +284,19 @@ func (p *Player) SetXWindow(windowID uint32) error {
 	return getError()
 }
 
+// EventManager gets the event manager from which the player sends events.
+func (p *Player) EventManager() *EventManager {
+	if p.player == nil {
+		return nil
+	}
+
+	manager := C.libvlc_media_player_event_manager(p.player)
+	if manager == nil {
+		return nil
+	}
+	return NewEventManager(manager)
+}
+
 func (p *Player) loadMedia(path string, local bool) (*Media, error) {
 	m, err := newMedia(path, local)
 	if err != nil {


### PR DESCRIPTION
See issue #18
Add event manager type, update events constants, wrap libvlc_media_player_event_manager.

I fixed up events.go from the adrg repo's master branch to match names and values from the libvlc sources. I created an eventmanager.go heavily based on the old adrg event branch. In that file I completed the TODOs, added a goCallback implementation and made the event registry variables into a a struct for easier housekeeping.

In player.go I wrapped libvlc_media_player_event_manager. I've tested the MediaPlayerEndReached event. I've not tested any other events or wrapped any other APIs for getting event managers. I'd have to construct apps for that, as my app doesn't need these events.