### PR TITLE
Implement additional AV bindings

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -81,10 +81,10 @@ Reference: [libVLC media player](https://www.videolan.org/developers/vlc/doc/dox
 |---|:------------------------------------------------|:-----------------------------|:-----------|
 | ☒ | libvlc_audio_output_list_get                    | vlc.AudioOutputList          | `v2`, `v3` |
 | ☒ | libvlc_audio_output_set                         | Player.SetAudioOutput        | `v2`, `v3` |
-| ☐ | libvlc_audio_output_device_enum                 |                              | `v2`, `v3` |
-| ☐ | libvlc_audio_output_device_list_get             |                              | `v2`, `v3` |
-| ☐ | libvlc_audio_output_device_set                  |                              | `v2`, `v3` |
-| ☐ | libvlc_audio_output_device_get                  |                              | `v3`       |
+| ☒ | libvlc_audio_output_device_enum                 | Player.AudioOutputDevices    | `v2`, `v3` |
+| ☒ | libvlc_audio_output_device_list_get             | vlc.ListAudioOutputDevices   | `v2`, `v3` |
+| ☒ | libvlc_audio_output_device_set                  | vlc.SetAudioOutputDevice     | `v2`, `v3` |
+| ☒ | libvlc_audio_output_device_get                  | vlc.AudioOutputDevice        | `v3`       |
 | ☒ | libvlc_audio_toggle_mute                        | Player.ToggleMute            | `v2`, `v3` |
 | ☒ | libvlc_audio_get_mute                           | Player.IsMuted               | `v2`, `v3` |
 | ☒ | libvlc_audio_set_mute                           | Player.SetMute               | `v2`, `v3` |
@@ -110,8 +110,8 @@ Reference: [libVLC media player](https://www.videolan.org/developers/vlc/doc/dox
 | ☒ | libvlc_audio_equalizer_set_amp_at_index         | Equalizer.SetAmpValueAtIndex | `v2`, `v3` |
 | ☒ | libvlc_audio_equalizer_get_amp_at_index         | Equalizer.AmpValueAtIndex    | `v2`, `v3` |
 | ☒ | libvlc_media_player_set_equalizer               | Player.SetEqualizer          | `v2`, `v3` |
-| ☐ | libvlc_media_player_get_role                    |                              | `v3`       |
-| ☐ | libvlc_media_player_set_role                    |                              | `v3`       |
+| ☒ | libvlc_media_player_get_role                    | Player.Role                  | `v3`       |
+| ☒ | libvlc_media_player_set_role                    | Player.SetRole               | `v3`       |
 
 Reference: [libVLC audio controls](https://www.videolan.org/developers/vlc/doc/doxygen/html/group__libvlc__audio.html).
 
@@ -124,14 +124,13 @@ Reference: [libVLC audio controls](https://www.videolan.org/developers/vlc/doc/d
 | ☒ | libvlc_get_fullscreen                             | Player.IsFullScreen             | `v2`, `v3` |
 | ☒ | libvlc_video_set_key_input                        | Player.SetKeyInput              | `v2`, `v3` |
 | ☒ | libvlc_video_set_mouse_input                      | Player.SetMouseInput            | `v2`, `v3` |
-| ☐ | libvlc_video_get_size                             |                                 | `v2`, `v3` |
-| ☐ | libvlc_video_get_cursor                           |                                 | `v2`, `v3` |
+| ☒ | libvlc_video_get_size                             | Player.VideoDimensions          | `v2`, `v3` |
+| ☒ | libvlc_video_get_cursor                           | Player.CursorPosition           | `v2`, `v3` |
 | ☒ | libvlc_video_get_scale                            | Player.Scale                    | `v2`, `v3` |
 | ☒ | libvlc_video_set_scale                            | Player.SetScale                 | `v2`, `v3` |
 | ☒ | libvlc_video_get_aspect_ratio                     | Player.AspectRatio              | `v2`, `v3` |
 | ☒ | libvlc_video_set_aspect_ratio                     | Player.SetAspectRatio           | `v2`, `v3` |
-| ☐ | libvlc_video_new_viewpoint                        |                                 | `v3`       |
-| ☐ | libvlc_video_update_viewpoint                     |                                 | `v3`       |
+| ☒ | libvlc_video_update_viewpoint                     | Player.UpdateVideoViewpoint     | `v3`       |
 | ☒ | libvlc_video_get_spu                              | Player.SubtitleTrackID          | `v2`, `v3` |
 | ☒ | libvlc_video_get_spu_count                        | Player.SubtitleTrackCount       | `v2`, `v3` |
 | ☒ | libvlc_video_get_spu_description                  | Player.SubtitleTrackDescriptors | `v2`, `v3` |

--- a/v2/av.go
+++ b/v2/av.go
@@ -74,9 +74,7 @@ func ListAudioOutputDevices(output string) ([]*AudioOutputDevice, error) {
 
 	cOutput := C.CString(output)
 	defer C.free(unsafe.Pointer(cOutput))
-
-	cDevices := C.libvlc_audio_output_device_list_get(inst.handle, cOutput)
-	return parseAudioOutputDeviceList(cDevices)
+	return parseAudioOutputDeviceList(C.libvlc_audio_output_device_list_get(inst.handle, cOutput))
 }
 
 func parseAudioOutputDeviceList(cDevices *C.libvlc_audio_output_device_t) ([]*AudioOutputDevice, error) {

--- a/v2/av.go
+++ b/v2/av.go
@@ -39,7 +39,7 @@ func AudioOutputList() ([]*AudioOutput, error) {
 	}
 
 	var outputs []*AudioOutput
-	for n := cOutputs; n != nil; n = (*C.libvlc_audio_output_t)(n.p_next) {
+	for n := cOutputs; n != nil; n = n.p_next {
 		outputs = append(outputs, &AudioOutput{
 			Name:        C.GoString(n.psz_name),
 			Description: C.GoString(n.psz_description),
@@ -82,7 +82,7 @@ func parseFilterList(cFilters *C.libvlc_module_description_t) ([]*ModuleDescript
 	}
 
 	var filters []*ModuleDescription
-	for n := cFilters; n != nil; n = (*C.libvlc_module_description_t)(n.p_next) {
+	for n := cFilters; n != nil; n = n.p_next {
 		filters = append(filters, &ModuleDescription{
 			Name:      C.GoString(n.psz_name),
 			ShortName: C.GoString(n.psz_shortname),

--- a/v2/av.go
+++ b/v2/av.go
@@ -4,6 +4,9 @@ package vlc
 // #include <vlc/vlc.h>
 // #include <stdlib.h>
 import "C"
+import (
+	"unsafe"
+)
 
 // StereoMode defines stereo modes which can be used by an audio output.
 type StereoMode int
@@ -19,15 +22,15 @@ const (
 	StereoModeDolbySurround
 )
 
-// AudioOutput is an abstraction for rendering decoded (or pass-through)
-// audio samples.
+// AudioOutput contains information regarding an audio output.
 type AudioOutput struct {
 	Name        string
 	Description string
 }
 
-// AudioOutputList returns a list of audio output devices that can be used
-// with an instance of a player.
+// AudioOutputList returns the list of available audio outputs.
+// In order to change the audio output of a media player instance,
+// use the Player.SetAudioOutput method.
 func AudioOutputList() ([]*AudioOutput, error) {
 	if err := inst.assertInit(); err != nil {
 		return nil, err
@@ -48,6 +51,49 @@ func AudioOutputList() ([]*AudioOutput, error) {
 
 	C.libvlc_audio_output_list_release(cOutputs)
 	return outputs, getError()
+}
+
+// AudioOutputDevice contains information regarding an audio output device.
+type AudioOutputDevice struct {
+	Name        string
+	Description string
+}
+
+// ListAudioOutputDevices returns the list of available devices for the
+// specified audio output. Use the AudioOutputList method in order to obtain
+// the list of available audio outputs. In order to change the audio output
+// device of a media player instance, use Player.SetAudioOutputDevice.
+// NOTE: Not all audio outputs support this. An empty list of devices does
+// not imply that the specified audio output does not work.
+// Some audio output devices in the list might not work in some circumstances.
+// By default, it is recommended to not specify any explicit audio device.
+func ListAudioOutputDevices(output string) ([]*AudioOutputDevice, error) {
+	if err := inst.assertInit(); err != nil {
+		return nil, err
+	}
+
+	cOutput := C.CString(output)
+	defer C.free(unsafe.Pointer(cOutput))
+
+	cDevices := C.libvlc_audio_output_device_list_get(inst.handle, cOutput)
+	return parseAudioOutputDeviceList(cDevices)
+}
+
+func parseAudioOutputDeviceList(cDevices *C.libvlc_audio_output_device_t) ([]*AudioOutputDevice, error) {
+	if cDevices == nil {
+		return nil, errOrDefault(getError(), ErrAudioOutputDeviceListMissing)
+	}
+
+	var devices []*AudioOutputDevice
+	for n := cDevices; n != nil; n = n.p_next {
+		devices = append(devices, &AudioOutputDevice{
+			Name:        C.GoString(n.psz_device),
+			Description: C.GoString(n.psz_description),
+		})
+	}
+
+	C.libvlc_audio_output_device_list_release(cDevices)
+	return devices, getError()
 }
 
 // ModuleDescription contains information about a libVLC module.

--- a/v2/errors.go
+++ b/v2/errors.go
@@ -29,6 +29,7 @@ var (
 	ErrMissingMediaStats       = errors.New("could not get media statistics")
 	ErrInvalidMediaStats       = errors.New("invalid media statistics")
 	ErrMissingMediaLocation    = errors.New("could not get media location")
+	ErrMissingMediaDimensions  = errors.New("could not get media dimensions")
 	ErrMediaMetaSave           = errors.New("could not save media metadata")
 )
 
@@ -52,6 +53,7 @@ var (
 	ErrAudioOutputDeviceListMissing = errors.New("could not get audio output device list")
 	ErrFilterListMissing            = errors.New("could not get filter list")
 	ErrStereoModeSet                = errors.New("could not set stereo mode")
+	ErrCursorPositionMissing        = errors.New("could not get cursor position")
 )
 
 // Equalizer errors.

--- a/v2/errors.go
+++ b/v2/errors.go
@@ -47,10 +47,11 @@ var (
 
 // Audio/Video errors.
 var (
-	ErrAudioOutputListMissing = errors.New("could not get audio output list")
-	ErrAudioOutputSet         = errors.New("could not set audio output")
-	ErrFilterListMissing      = errors.New("could not get filter list")
-	ErrStereoModeSet          = errors.New("could not set stereo mode")
+	ErrAudioOutputListMissing       = errors.New("could not get audio output list")
+	ErrAudioOutputSet               = errors.New("could not set audio output")
+	ErrAudioOutputDeviceListMissing = errors.New("could not get audio output device list")
+	ErrFilterListMissing            = errors.New("could not get filter list")
+	ErrStereoModeSet                = errors.New("could not set stereo mode")
 )
 
 // Equalizer errors.

--- a/v2/media.go
+++ b/v2/media.go
@@ -373,9 +373,9 @@ func (m *Media) Parse() error {
 }
 
 // ParseAsync fetches local art, metadata and track information asynchronously.
-// Listen to MediaParsedChanged event on the media event manager the track when
-// the parsing has finished. However, if the media was already parsed, the
-// event will not be sent.
+// Listen to the MediaParsedChanged event on the media event manager the track
+// when the parsing has finished. However, if the media was already parsed,
+// the event is not sent.
 func (m *Media) ParseAsync() error {
 	if err := m.assertInit(); err != nil {
 		return err

--- a/v2/media.go
+++ b/v2/media.go
@@ -514,7 +514,7 @@ func (m *Media) getUserData() (objectID, *mediaData) {
 	if err := inst.assertInit(); err != nil {
 		return nil, nil
 	}
-	id := objectID(C.libvlc_media_get_user_data(m.media))
+	id := C.libvlc_media_get_user_data(m.media)
 
 	obj, ok := inst.objects.get(id)
 	if !ok {

--- a/v2/media_track.go
+++ b/v2/media_track.go
@@ -150,7 +150,7 @@ func parseMediaTrackDescriptorList(cDescriptors *C.libvlc_track_description_t) (
 	}
 
 	var descriptors []*MediaTrackDescriptor
-	for n := cDescriptors; n != nil; n = (*C.libvlc_track_description_t)(n.p_next) {
+	for n := cDescriptors; n != nil; n = n.p_next {
 		descriptors = append(descriptors, &MediaTrackDescriptor{
 			ID:          int(n.i_id),
 			Description: C.GoString(n.psz_name),

--- a/v2/player.go
+++ b/v2/player.go
@@ -332,7 +332,7 @@ func (p *Player) AudioOutputDevices() ([]*AudioOutputDevice, error) {
 // The syntax for the `device` parameter depends on the audio output.
 // Some audio output modules require further parameters.
 // Due to a design bug in libVLC, the method does not return an error if the
-// passed in device could not be set.
+// passed in device cannot be set.
 func (p *Player) SetAudioOutputDevice(device, output string) error {
 	if err := p.assertInit(); err != nil {
 		return err
@@ -738,7 +738,7 @@ func (p *Player) VideoDimensions() (uint, uint, error) {
 	return uint(w), uint(h), nil
 }
 
-// CursorPosition returns the X and Y coordinates of the mouse cursor,
+// CursorPosition returns the X and Y coordinates of the mouse cursor
 // relative to the rendered area of the currently playing video.
 // NOTE: The coordinates are expressed in terms of the decoded video
 // resolution, not in terms of pixels on the screen. Either coordinate may

--- a/v2/player.go
+++ b/v2/player.go
@@ -319,8 +319,7 @@ func (p *Player) AudioOutputDevices() ([]*AudioOutputDevice, error) {
 		return nil, err
 	}
 
-	cDevices := C.libvlc_audio_output_device_enum(p.player)
-	return parseAudioOutputDeviceList(cDevices)
+	return parseAudioOutputDeviceList(C.libvlc_audio_output_device_enum(p.player))
 }
 
 // SetAudioOutputDevice sets the audio output device to be used by the
@@ -747,7 +746,7 @@ func (p *Player) VideoDimensions() (uint, uint, error) {
 // the cursor is outside the rendering area.
 // The coordinates may be out of date if the pointer is not located on the
 // video rendering area. libVLC does not track the pointer if it is outside
-// of the video widget. Also, libVLC does not support multiple pointers.
+// of the video widget. Also, libVLC does not support multiple cursors.
 func (p *Player) CursorPosition() (int, int, error) {
 	if err := p.assertInit(); err != nil {
 		return 0, 0, err

--- a/v3/av.go
+++ b/v3/av.go
@@ -23,8 +23,7 @@ const (
 	StereoModeHeadphones
 )
 
-// AudioOutput is an abstraction for rendering decoded (or pass-through)
-// audio samples.
+// AudioOutput contains information regarding an audio output.
 type AudioOutput struct {
 	Name        string
 	Description string

--- a/v3/av.go
+++ b/v3/av.go
@@ -4,6 +4,9 @@ package vlc
 // #include <vlc/vlc.h>
 // #include <stdlib.h>
 import "C"
+import (
+	"unsafe"
+)
 
 // StereoMode defines stereo modes which can be used by an audio output.
 type StereoMode int
@@ -27,8 +30,9 @@ type AudioOutput struct {
 	Description string
 }
 
-// AudioOutputList returns a list of audio output devices that can be used
-// with an instance of a player.
+// AudioOutputList returns the list of available audio outputs.
+// In order to change the audio output of a media player instance,
+// use the Player.SetAudioOutput method.
 func AudioOutputList() ([]*AudioOutput, error) {
 	if err := inst.assertInit(); err != nil {
 		return nil, err
@@ -49,6 +53,47 @@ func AudioOutputList() ([]*AudioOutput, error) {
 
 	C.libvlc_audio_output_list_release(cOutputs)
 	return outputs, getError()
+}
+
+// AudioOutputDevice contains information regarding an audio output device.
+type AudioOutputDevice struct {
+	Name        string
+	Description string
+}
+
+// ListAudioOutputDevices returns the list of available devices for the
+// specified audio output. Use the AudioOutputList method in order to obtain
+// the list of available audio outputs.
+// NOTE: Not all audio outputs support this. An empty list of devices does
+// not imply that the specified audio output does not work.
+// Some audio output devices in the list might not work in some circumstances.
+func ListAudioOutputDevices(output string) ([]*AudioOutputDevice, error) {
+	if err := inst.assertInit(); err != nil {
+		return nil, err
+	}
+
+	cOutput := C.CString(output)
+	defer C.free(unsafe.Pointer(cOutput))
+
+	cDevices := C.libvlc_audio_output_device_list_get(inst.handle, cOutput)
+	return parseAudioOutputDeviceList(cDevices)
+}
+
+func parseAudioOutputDeviceList(cDevices *C.libvlc_audio_output_device_t) ([]*AudioOutputDevice, error) {
+	if cDevices == nil {
+		return nil, errOrDefault(getError(), ErrAudioOutputDeviceListMissing)
+	}
+
+	var devices []*AudioOutputDevice
+	for n := cDevices; n != nil; n = n.p_next {
+		devices = append(devices, &AudioOutputDevice{
+			Name:        C.GoString(n.psz_device),
+			Description: C.GoString(n.psz_description),
+		})
+	}
+
+	C.libvlc_audio_output_device_list_release(cDevices)
+	return devices, getError()
 }
 
 // ModuleDescription contains information about a libVLC module.

--- a/v3/av.go
+++ b/v3/av.go
@@ -67,6 +67,7 @@ type AudioOutputDevice struct {
 // NOTE: Not all audio outputs support this. An empty list of devices does
 // not imply that the specified audio output does not work.
 // Some audio output devices in the list might not work in some circumstances.
+// By default, it is recommended to not specify any explicit audio device.
 func ListAudioOutputDevices(output string) ([]*AudioOutputDevice, error) {
 	if err := inst.assertInit(); err != nil {
 		return nil, err

--- a/v3/av.go
+++ b/v3/av.go
@@ -75,9 +75,7 @@ func ListAudioOutputDevices(output string) ([]*AudioOutputDevice, error) {
 
 	cOutput := C.CString(output)
 	defer C.free(unsafe.Pointer(cOutput))
-
-	cDevices := C.libvlc_audio_output_device_list_get(inst.handle, cOutput)
-	return parseAudioOutputDeviceList(cDevices)
+	return parseAudioOutputDeviceList(C.libvlc_audio_output_device_list_get(inst.handle, cOutput))
 }
 
 func parseAudioOutputDeviceList(cDevices *C.libvlc_audio_output_device_t) ([]*AudioOutputDevice, error) {

--- a/v3/av.go
+++ b/v3/av.go
@@ -62,7 +62,8 @@ type AudioOutputDevice struct {
 
 // ListAudioOutputDevices returns the list of available devices for the
 // specified audio output. Use the AudioOutputList method in order to obtain
-// the list of available audio outputs.
+// the list of available audio outputs. In order to change the audio output
+// device of a media player instance, use Player.SetAudioOutputDevice.
 // NOTE: Not all audio outputs support this. An empty list of devices does
 // not imply that the specified audio output does not work.
 // Some audio output devices in the list might not work in some circumstances.

--- a/v3/av.go
+++ b/v3/av.go
@@ -40,7 +40,7 @@ func AudioOutputList() ([]*AudioOutput, error) {
 	}
 
 	var outputs []*AudioOutput
-	for n := cOutputs; n != nil; n = (*C.libvlc_audio_output_t)(n.p_next) {
+	for n := cOutputs; n != nil; n = n.p_next {
 		outputs = append(outputs, &AudioOutput{
 			Name:        C.GoString(n.psz_name),
 			Description: C.GoString(n.psz_description),
@@ -83,7 +83,7 @@ func parseFilterList(cFilters *C.libvlc_module_description_t) ([]*ModuleDescript
 	}
 
 	var filters []*ModuleDescription
-	for n := cFilters; n != nil; n = (*C.libvlc_module_description_t)(n.p_next) {
+	for n := cFilters; n != nil; n = n.p_next {
 		filters = append(filters, &ModuleDescription{
 			Name:      C.GoString(n.psz_name),
 			ShortName: C.GoString(n.psz_shortname),

--- a/v3/errors.go
+++ b/v3/errors.go
@@ -58,7 +58,6 @@ var (
 	ErrFilterListMissing            = errors.New("could not get filter list")
 	ErrStereoModeSet                = errors.New("could not set stereo mode")
 	ErrVideoViewpointSet            = errors.New("could not set video viewpoint")
-	ErrVideoViewpointNotInitialized = errors.New("video viewpoint not initialized")
 	ErrCursorPositionMissing        = errors.New("could not get cursor position")
 )
 

--- a/v3/errors.go
+++ b/v3/errors.go
@@ -59,6 +59,7 @@ var (
 	ErrStereoModeSet                = errors.New("could not set stereo mode")
 	ErrVideoViewpointSet            = errors.New("could not set video viewpoint")
 	ErrVideoViewpointNotInitialized = errors.New("video viewpoint not initialized")
+	ErrCursorPositionMissing        = errors.New("could not get cursor position")
 )
 
 // Renderer discoverer errors.

--- a/v3/errors.go
+++ b/v3/errors.go
@@ -53,6 +53,7 @@ var (
 	ErrAudioOutputListMissing       = errors.New("could not get audio output list")
 	ErrAudioOutputSet               = errors.New("could not set audio output")
 	ErrAudioOutputDeviceListMissing = errors.New("could not get audio output device list")
+	ErrAudioOutputDeviceMissing     = errors.New("could not get audio output device")
 	ErrFilterListMissing            = errors.New("could not get filter list")
 	ErrStereoModeSet                = errors.New("could not set stereo mode")
 )

--- a/v3/errors.go
+++ b/v3/errors.go
@@ -31,6 +31,7 @@ var (
 	ErrMissingMediaStats       = errors.New("could not get media statistics")
 	ErrInvalidMediaStats       = errors.New("invalid media statistics")
 	ErrMissingMediaLocation    = errors.New("could not get media location")
+	ErrMissingMediaDimensions  = errors.New("could not get media dimensions")
 	ErrMediaMetaSave           = errors.New("could not save media metadata")
 	ErrMediaParse              = errors.New("could not parse media")
 )

--- a/v3/errors.go
+++ b/v3/errors.go
@@ -15,6 +15,7 @@ var (
 	ErrPlayerNotInitialized     = errors.New("player not initialized")
 	ErrPlayerSetRenderer        = errors.New("could not set player renderer")
 	ErrPlayerSetEqualizer       = errors.New("could not set player equalizer")
+	ErrPlayerInvalidRole        = errors.New("invalid player role")
 	ErrListPlayerCreate         = errors.New("could not create list player")
 	ErrListPlayerNotInitialized = errors.New("list player not initialized")
 )

--- a/v3/errors.go
+++ b/v3/errors.go
@@ -56,6 +56,8 @@ var (
 	ErrAudioOutputDeviceMissing     = errors.New("could not get audio output device")
 	ErrFilterListMissing            = errors.New("could not get filter list")
 	ErrStereoModeSet                = errors.New("could not set stereo mode")
+	ErrVideoViewpointSet            = errors.New("could not set video viewpoint")
+	ErrVideoViewpointNotInitialized = errors.New("video viewpoint not initialized")
 )
 
 // Renderer discoverer errors.

--- a/v3/errors.go
+++ b/v3/errors.go
@@ -50,10 +50,11 @@ var (
 
 // Audio/Video errors.
 var (
-	ErrAudioOutputListMissing = errors.New("could not get audio output list")
-	ErrAudioOutputSet         = errors.New("could not set audio output")
-	ErrFilterListMissing      = errors.New("could not get filter list")
-	ErrStereoModeSet          = errors.New("could not set stereo mode")
+	ErrAudioOutputListMissing       = errors.New("could not get audio output list")
+	ErrAudioOutputSet               = errors.New("could not set audio output")
+	ErrAudioOutputDeviceListMissing = errors.New("could not get audio output device list")
+	ErrFilterListMissing            = errors.New("could not get filter list")
+	ErrStereoModeSet                = errors.New("could not set stereo mode")
 )
 
 // Renderer discoverer errors.

--- a/v3/media.go
+++ b/v3/media.go
@@ -683,7 +683,7 @@ func (m *Media) getUserData() (objectID, *mediaData) {
 	if err := inst.assertInit(); err != nil {
 		return nil, nil
 	}
-	id := objectID(C.libvlc_media_get_user_data(m.media))
+	id := C.libvlc_media_get_user_data(m.media)
 
 	obj, ok := inst.objects.get(id)
 	if !ok {

--- a/v3/media_discoverer.go
+++ b/v3/media_discoverer.go
@@ -202,7 +202,7 @@ func (md *MediaDiscoverer) Start(cb MediaDiscoveryCallback) error {
 		MediaListItemDeleted,
 	}
 
-	var eventIDs []EventID
+	eventIDs := make([]EventID, 0, len(events))
 	for _, event := range events {
 		eventID, err := manager.attach(event, nil, eventCallback, nil)
 		if err != nil {

--- a/v3/media_track.go
+++ b/v3/media_track.go
@@ -227,7 +227,7 @@ func parseMediaTrackDescriptorList(cDescriptors *C.libvlc_track_description_t) (
 	}
 
 	var descriptors []*MediaTrackDescriptor
-	for n := cDescriptors; n != nil; n = (*C.libvlc_track_description_t)(n.p_next) {
+	for n := cDescriptors; n != nil; n = n.p_next {
 		descriptors = append(descriptors, &MediaTrackDescriptor{
 			ID:          int(n.i_id),
 			Description: C.GoString(n.psz_name),

--- a/v3/player.go
+++ b/v3/player.go
@@ -892,6 +892,28 @@ func (p *Player) UpdateVideoViewpoint(vp *VideoViewpoint, absolute bool) error {
 	return nil
 }
 
+// CursorPosition returns the X and Y coordinates of the mouse cursor,
+// relative to the rendered area of the currently playing video.
+// NOTE: The coordinates are expressed in terms of the decoded video
+// resolution, not in terms of pixels on the screen. Either coordinate may
+// be negative or larger than the corresponding dimension of the video, if
+// the cursor is outside the rendering area.
+// The coordinates may be out of date if the pointer is not located on the
+// video rendering area. libVLC does not track the pointer if it is outside
+// of the video widget. Also, libVLC does not support multiple pointers.
+func (p *Player) CursorPosition() (int, int, error) {
+	if err := p.assertInit(); err != nil {
+		return 0, 0, err
+	}
+
+	var x, y C.int
+	if C.libvlc_video_get_cursor(p.player, 0, &x, &y) != 0 {
+		return 0, 0, errOrDefault(getError(), ErrCursorPositionMissing)
+	}
+
+	return int(x), int(y), nil
+}
+
 // XWindow returns the identifier of the X window the media player is
 // configured to render its video output to, or 0 if no window is set.
 // The window can be set using the SetXWindow method.

--- a/v3/player.go
+++ b/v3/player.go
@@ -398,6 +398,23 @@ func (p *Player) AudioOutputDevice() (string, error) {
 	return C.GoString(cName), nil
 }
 
+// SetAudioOutputDevice sets the audio output device to be used by the
+// media player. The list of available devices can be obtained using the
+// Player.AudioOutputDevices method.
+// NOTE: The syntax for the device parameter depends on the audio output.
+// Some audio output modules require further parameters.
+func (p *Player) SetAudioOutputDevice(device string) error {
+	if err := p.assertInit(); err != nil {
+		return err
+	}
+
+	cDevice := C.CString(device)
+	C.libvlc_audio_output_device_set(p.player, nil, cDevice)
+	C.free(unsafe.Pointer(cDevice))
+
+	return getError()
+}
+
 // StereoMode returns the stereo mode of the audio output used by the player.
 func (p *Player) StereoMode() (StereoMode, error) {
 	if err := p.assertInit(); err != nil {

--- a/v3/player.go
+++ b/v3/player.go
@@ -376,6 +376,28 @@ func (p *Player) AudioOutputDevices() ([]*AudioOutputDevice, error) {
 	return parseAudioOutputDeviceList(cDevices)
 }
 
+// AudioOutputDevice returns the name of the current audio output device
+// used by the media player.
+// NOTE: The initial value for the current audio output device identifier
+// may not be set or may be an unknown value. Applications should compare
+// the returned value against the known device identifiers to find the
+// current audio output device. It is possible for the audio output device
+// to be changed externally. That may make the method unsuitable to use for
+// applications which are attempting to track audio device changes.
+func (p *Player) AudioOutputDevice() (string, error) {
+	if err := p.assertInit(); err != nil {
+		return "", err
+	}
+
+	cName := C.libvlc_audio_output_device_get(p.player)
+	if cName == nil {
+		return "", ErrAudioOutputDeviceMissing
+	}
+	defer C.free(unsafe.Pointer(cName))
+
+	return C.GoString(cName), nil
+}
+
 // StereoMode returns the stereo mode of the audio output used by the player.
 func (p *Player) StereoMode() (StereoMode, error) {
 	if err := p.assertInit(); err != nil {

--- a/v3/player.go
+++ b/v3/player.go
@@ -361,6 +361,21 @@ func (p *Player) SetAudioOutput(output string) error {
 	return nil
 }
 
+// AudioOutputDevices returns the list of available devices for the
+// audio output used by the media player.
+// NOTE: Not all audio outputs support this. An empty list of devices does
+// not imply that the audio output used by the player does not work.
+// Some audio output devices in the list might not work in some circumstances.
+// By default, it is recommended to not specify any explicit audio device.
+func (p *Player) AudioOutputDevices() ([]*AudioOutputDevice, error) {
+	if err := p.assertInit(); err != nil {
+		return nil, err
+	}
+
+	cDevices := C.libvlc_audio_output_device_enum(p.player)
+	return parseAudioOutputDeviceList(cDevices)
+}
+
 // StereoMode returns the stereo mode of the audio output used by the player.
 func (p *Player) StereoMode() (StereoMode, error) {
 	if err := p.assertInit(); err != nil {

--- a/v3/player.go
+++ b/v3/player.go
@@ -405,7 +405,7 @@ func (p *Player) AudioOutputDevice() (string, error) {
 // NOTE: The syntax for the `device` parameter depends on the audio output.
 // Some audio output modules require further parameters.
 // Due to a design bug in libVLC, the method does not return an error if the
-// passed in device could not be set. Use the Player.AudioOutputDevice method
+// passed in device cannot be set. Use the Player.AudioOutputDevice method
 // to check if the device has been set.
 func (p *Player) SetAudioOutputDevice(device, output string) error {
 	if err := p.assertInit(); err != nil {
@@ -891,7 +891,7 @@ func (p *Player) UpdateVideoViewpoint(vp *VideoViewpoint, absolute bool) error {
 	return nil
 }
 
-// CursorPosition returns the X and Y coordinates of the mouse cursor,
+// CursorPosition returns the X and Y coordinates of the mouse cursor
 // relative to the rendered area of the currently playing video.
 // NOTE: The coordinates are expressed in terms of the decoded video
 // resolution, not in terms of pixels on the screen. Either coordinate may

--- a/v3/player.go
+++ b/v3/player.go
@@ -796,7 +796,7 @@ func (p *Player) SetRenderer(r *Renderer) error {
 }
 
 // SetEqualizer sets an equalizer for the player. The equalizer can be applied
-// at any moment (whether media playback is started or not) and it will be used
+// at any time (whether media playback is started or not) and it will be used
 // for subsequently played media instances as well. In order to revert to the
 // default equalizer, pass in `nil` as the equalizer parameter.
 func (p *Player) SetEqualizer(e *Equalizer) error {
@@ -841,9 +841,27 @@ func (p *Player) SetRole(role PlayerRole) error {
 	return nil
 }
 
-// UpdateVideoViewpoint updates the viewpoint of 360° videos. If `absolute`
-// is true, the passed in viewpoint replaces the current one. Otherwise, the
-// current viewpoint is updated using the specified viewpoint values.
+// VideoDimensions returns the width and height of the current media of
+// the player, in pixels.
+// NOTE: The dimensions can only be obtained for parsed media instances.
+// Either play the media or call one of the media parsing methods first.
+func (p *Player) VideoDimensions() (uint, uint, error) {
+	if err := p.assertInit(); err != nil {
+		return 0, 0, err
+	}
+
+	var w, h C.uint
+	if C.libvlc_video_get_size(p.player, 0, &w, &h) != 0 {
+		return 0, 0, errOrDefault(getError(), ErrMissingMediaDimensions)
+	}
+
+	return uint(w), uint(h), nil
+}
+
+// UpdateVideoViewpoint updates the viewpoint of the current media of the
+// player. This method only works with 360° videos. If `absolute` is true,
+// the passed in viewpoint replaces the current one. Otherwise, the current
+// viewpoint is updated using the specified viewpoint values.
 // NOTE: It is safe to call this method before media playback is started.
 func (p *Player) UpdateVideoViewpoint(vp *VideoViewpoint, absolute bool) error {
 	if err := p.assertInit(); err != nil {

--- a/v3/player.go
+++ b/v3/player.go
@@ -10,6 +10,42 @@ import (
 	"unsafe"
 )
 
+// PlayerRole defines the intended usage of a media player.
+type PlayerRole uint
+
+// Player roles.
+const (
+	// No role has been set.
+	PlayerRoleNone PlayerRole = iota
+
+	// Music (or radio) playback.
+	PlayerRoleMusic
+
+	// Video playback.
+	PlayerRoleVideo
+
+	// Speech, real-time communication.
+	PlayerRoleCommunication
+
+	// Video games.
+	PlayerRoleGame
+
+	// User interaction feedback.
+	PlayerRoleNotification
+
+	// Embedded animations (e.g. in a web page).
+	PlayerRoleAnimation
+
+	// Editing or production.
+	PlayerRoleProduction
+
+	// Accessibility.
+	PlayerRoleAccessibility
+
+	// Testing.
+	PlayerRoleTest
+)
+
 // Player is a media player used to play a single media file.
 // For playing media lists (playlists) use ListPlayer instead.
 type Player struct {

--- a/v3/player.go
+++ b/v3/player.go
@@ -372,8 +372,7 @@ func (p *Player) AudioOutputDevices() ([]*AudioOutputDevice, error) {
 		return nil, err
 	}
 
-	cDevices := C.libvlc_audio_output_device_enum(p.player)
-	return parseAudioOutputDeviceList(cDevices)
+	return parseAudioOutputDeviceList(C.libvlc_audio_output_device_enum(p.player))
 }
 
 // AudioOutputDevice returns the name of the current audio output device
@@ -868,7 +867,7 @@ func (p *Player) UpdateVideoViewpoint(vp *VideoViewpoint, absolute bool) error {
 		return err
 	}
 	if vp == nil {
-		return ErrVideoViewpointNotInitialized
+		return ErrVideoViewpointSet
 	}
 
 	// Create new viewpoint.
@@ -900,7 +899,7 @@ func (p *Player) UpdateVideoViewpoint(vp *VideoViewpoint, absolute bool) error {
 // the cursor is outside the rendering area.
 // The coordinates may be out of date if the pointer is not located on the
 // video rendering area. libVLC does not track the pointer if it is outside
-// of the video widget. Also, libVLC does not support multiple pointers.
+// of the video widget. Also, libVLC does not support multiple cursors.
 func (p *Player) CursorPosition() (int, int, error) {
 	if err := p.assertInit(); err != nil {
 		return 0, 0, err

--- a/v3/player.go
+++ b/v3/player.go
@@ -749,6 +749,33 @@ func (p *Player) SetEqualizer(e *Equalizer) error {
 	return nil
 }
 
+// Role returns the role of the player.
+func (p *Player) Role() (PlayerRole, error) {
+	if err := p.assertInit(); err != nil {
+		return 0, err
+	}
+
+	role := C.libvlc_media_player_get_role(p.player)
+	if role < 0 {
+		return 0, errOrDefault(getError(), ErrPlayerInvalidRole)
+	}
+
+	return PlayerRole(role), nil
+}
+
+// SetRole sets the role of the player.
+func (p *Player) SetRole(role PlayerRole) error {
+	if err := p.assertInit(); err != nil {
+		return err
+	}
+
+	if C.libvlc_media_player_set_role(p.player, C.uint(role)) != 0 {
+		return errOrDefault(getError(), ErrPlayerInvalidRole)
+	}
+
+	return nil
+}
+
 // XWindow returns the identifier of the X window the media player is
 // configured to render its video output to, or 0 if no window is set.
 // The window can be set using the SetXWindow method.

--- a/v3/renderer_discoverer.go
+++ b/v3/renderer_discoverer.go
@@ -177,7 +177,7 @@ func (rd *RendererDiscoverer) Start(cb RendererDiscoveryCallback) error {
 		RendererDiscovererItemAdded, RendererDiscovererItemDeleted,
 	}
 
-	var eventIDs []EventID
+	eventIDs := make([]EventID, 0, len(events))
 	for _, event := range events {
 		eventID, err := manager.attach(event, nil, eventCallback, nil)
 		if err != nil {


### PR DESCRIPTION
- Add `vlc.ListAudioOutputDevices` method
- Add `Player.AudioOutputDevices` method
- Add `Player.AudioOutputDevice` and `Player.SetAudioOutputDevice` methods
- Add `Player.Role` and `Player.GetRole` methods
- Add `Player.UpdateVideoViewpoint` method
- Add `Player.VideoDimensions` method
- Add `Player.CursorPosition` method
- Fix relevant `golangci-lint` notices
- Improve documentation