### PR TITLE
Player: Add video module Marquee and Logo

### DIFF
--- a/v3/player.go
+++ b/v3/player.go
@@ -1355,3 +1355,77 @@ func (p *Player) assertInit() error {
 
 	return nil
 }
+
+type VideoLogoIntOption uint
+type VideoLogoStringOption uint
+
+const (
+	VideoLogoEnable   VideoLogoIntOption    = C.libvlc_logo_enable
+	VideoLogoFile     VideoLogoStringOption = C.libvlc_logo_file
+	VideoLogoX        VideoLogoIntOption    = C.libvlc_logo_x
+	VideoLogoY        VideoLogoIntOption    = C.libvlc_logo_y
+	VideoLogoDelay    VideoLogoIntOption    = C.libvlc_logo_delay
+	VideoLogoRepeat   VideoLogoIntOption    = C.libvlc_logo_repeat
+	VideoLogoOpacity  VideoLogoIntOption    = C.libvlc_logo_opacity
+	VideoLogoPosition VideoLogoIntOption    = C.libvlc_logo_position
+)
+
+type VideoMarqueeIntOption uint
+type VideoMarqueeStringOption uint
+
+const (
+	VideoMaqueeEnable    VideoMarqueeIntOption    = C.libvlc_marquee_Enable
+	VideoMarqueeText     VideoMarqueeStringOption = C.libvlc_marquee_Text
+	VideoMarqueeColor    VideoMarqueeIntOption    = C.libvlc_marquee_Color
+	VideoMarqueeOpacity  VideoMarqueeIntOption    = C.libvlc_marquee_Opacity
+	VideoMarqueePosition VideoMarqueeIntOption    = C.libvlc_marquee_Position
+	VideoMarqueeRefresh  VideoMarqueeIntOption    = C.libvlc_marquee_Refresh
+	VideoMarqueeSize     VideoMarqueeIntOption    = C.libvlc_marquee_Size
+	VideoMarqueeTimeout  VideoMarqueeIntOption    = C.libvlc_marquee_Timeout
+	VideoMarqueeX        VideoMarqueeIntOption    = C.libvlc_marquee_X
+	VideoMarqueeY        VideoMarqueeIntOption    = C.libvlc_marquee_Y
+)
+
+func (p *Player) SetVideoLogoInt(option VideoLogoIntOption, value int) {
+	if err := p.assertInit(); err != nil {
+		return
+	}
+	C.libvlc_video_set_logo_int(p.player, C.uint(option), C.int(value))
+}
+
+func (p *Player) GetVideoLogoInt(option VideoLogoIntOption) int {
+	return int(C.libvlc_video_get_logo_int(p.player, C.uint(option)))
+}
+
+func (p *Player) SetVideoLogoString(option VideoLogoStringOption, value string) {
+	if err := p.assertInit(); err != nil {
+		return
+	}
+	cs := C.CString(value)
+	C.libvlc_video_set_logo_string(p.player, C.uint(option), (*C.char)(cs))
+	C.free(unsafe.Pointer(cs))
+}
+
+func (p *Player) SetVideoMarqueeInt(option VideoMarqueeIntOption, value int) {
+	if err := p.assertInit(); err != nil {
+		return
+	}
+	C.libvlc_video_set_marquee_int(p.player, C.uint(option), C.int(value))
+}
+
+func (p *Player) GetVideoMarqueeInt(option VideoMarqueeIntOption) int {
+        return int(C.libvlc_video_get_marquee_int(p.player, C.uint(option)))
+}
+
+func (p *Player) SetVideoMarqueeString(option VideoMarqueeStringOption, value string) {
+	if err := p.assertInit(); err != nil {
+		return
+	}
+	cs := C.CString(value)
+	C.libvlc_video_set_marquee_string(p.player, C.uint(option), (*C.char)(cs))
+	C.free(unsafe.Pointer(cs))
+}
+
+func (p *Player) GetVideoMarqueeString(option VideoMarqueeStringOption) (string) {
+	return C.GoString(C.libvlc_video_get_marquee_string(p.player, C.uint(option)))
+}


### PR DESCRIPTION
This Pull Request allow the usage of Marquee and Logo VLC Modules :
https://wiki.videolan.org/Documentation:Modules/logo/
https://wiki.videolan.org/Documentation:Modules/marq/

This sample code bellow display the meta data Title in bottom center of the current video for 10 seconds :
```
                case vlc.MediaParsedChanged:
                        ...
                        marquee, err := media.Meta(vlc.MediaTitle)
                        ...
                        p.SetVideoMarqueeString(vlc.VideoMarqueeText, marquee)
                        p.SetVideoMarqueeInt(vlc.VideoMarqueePosition, 8)
                        p.SetVideoMarqueeInt(vlc.VideoMarqueeOpacity, 200)
                        p.SetVideoMarqueeInt(vlc.VideoMarqueeTimeout, 10000)
                        p.SetVideoMarqueeInt(vlc.VideoMarqueeColor, 0xffc107)
                        p.SetVideoMarqueeInt(vlc.VideoMaqueeEnable, 1)

```
player must be playing a video in order to set filter, i don't know how to assert this yet

Best regards,
DUPONCHEEL Sébastien