### PR TITLE
Adjust dispatch C function

### DIFF
--- a/v3/event_manager.go
+++ b/v3/event_manager.go
@@ -4,7 +4,8 @@ package vlc
 #cgo LDFLAGS: -lvlc
 #include <vlc/vlc.h>
 
-extern void eventDispatch(libvlc_event_t*, void*);
+typedef const libvlc_event_t constev;
+extern void eventDispatch(constev*, void*);
 
 static inline int eventAttach(libvlc_event_manager_t* em, libvlc_event_type_t et, unsigned long userData) {
     return libvlc_event_attach(em, et, eventDispatch, (void*)userData);
@@ -72,7 +73,7 @@ func (em *EventManager) Detach(eventIDs ...EventID) {
 }
 
 //export eventDispatch
-func eventDispatch(event *C.libvlc_event_t, userData unsafe.Pointer) {
+func eventDispatch(event *C.constev, userData unsafe.Pointer) {
 	if err := inst.assertInit(); err != nil {
 		return
 	}


### PR DESCRIPTION
Since i updated libvlc today, i could not build libvlc-go without warnings anymore.

```# github.com/adrg/libvlc-go/v3
../libvlc-go/v3/event_manager.go: In function 'eventAttach':
../libvlc-go/v3/event_manager.go:10:40: error: passing argument 3 of 'libvlc_event_attach' from incompatible pointer type [-Wincompatible-pointer-types]
   10 |     return libvlc_event_attach(em, et, eventDispatch, (void*)userData);
      |                                        ^~~~~~~~~~~~~
      |                                        |
      |                                        void (*)(libvlc_event_t *, void *)
In file included from /usr/include/vlc/vlc.h:40,
                 from ../libvlc-go/v3/event_manager.go:5:
/usr/include/vlc/libvlc.h:339:59: note: expected 'libvlc_callback_t' {aka 'void (*)(const struct libvlc_event_t *, void *)'} but argument is of type 'void (*)(libvlc_event_t *, void *)'
  339 |                                         libvlc_callback_t f_callback,
      |                                         ~~~~~~~~~~~~~~~~~~^~~~~~~~~~
../libvlc-go/v3/event_manager.go: In function 'eventDetach':
../libvlc-go/v3/event_manager.go:13:33: error: passing argument 3 of 'libvlc_event_detach' from incompatible pointer type [-Wincompatible-pointer-types]
   13 |     libvlc_event_detach(em, et, eventDispatch, (void*)userData);
      |                                 ^~~~~~~~~~~~~
      |                                 |
      |                                 void (*)(libvlc_event_t *, void *)
/usr/include/vlc/libvlc.h:352:60: note: expected 'libvlc_callback_t' {aka 'void (*)(const struct libvlc_event_t *, void *)'} but argument is of type 'void (*)(libvlc_event_t *, void *)'
  352 |                                          libvlc_callback_t f_callback,
      |                                          ~~~~~~~~~~~~~~~~~~^~~~~~~~~~
```

This PR adjusts the dispatch functions signature in order to fix the warnings.

See: https://github.com/videolan/vlc/blob/master/include/vlc/libvlc.h#L325