### PR TITLE
Use pkg-config instead of manual -lvlc

### DIFF
--- a/v3/av.go
+++ b/v3/av.go
@@ -1,6 +1,5 @@
 package vlc
 
-// #cgo LDFLAGS: -lvlc
 // #include <vlc/vlc.h>
 // #include <stdlib.h>
 import "C"

--- a/v3/cgo_vlc.go
+++ b/v3/cgo_vlc.go
@@ -1,0 +1,4 @@
+package vlc
+
+// #cgo pkg-config: libvlc
+import "C"

--- a/v3/equalizer.go
+++ b/v3/equalizer.go
@@ -1,6 +1,5 @@
 package vlc
 
-// #cgo LDFLAGS: -lvlc
 // #include <vlc/vlc.h>
 import "C"
 

--- a/v3/event_manager.go
+++ b/v3/event_manager.go
@@ -1,7 +1,6 @@
 package vlc
 
 /*
-#cgo LDFLAGS: -lvlc
 #include <vlc/vlc.h>
 
 typedef const libvlc_event_t constev;

--- a/v3/event_registry.go
+++ b/v3/event_registry.go
@@ -1,6 +1,5 @@
 package vlc
 
-// #cgo LDFLAGS: -lvlc
 // #include <vlc/vlc.h>
 import "C"
 import "sync"

--- a/v3/list_player.go
+++ b/v3/list_player.go
@@ -3,7 +3,6 @@
 
 package vlc
 
-// #cgo LDFLAGS: -lvlc
 // #include <vlc/vlc.h>
 // #include <stdlib.h>
 import "C"

--- a/v3/logo.go
+++ b/v3/logo.go
@@ -1,7 +1,6 @@
 package vlc
 
 /*
-#cgo LDFLAGS: -lvlc
 #include <vlc/vlc.h>
 #include <stdlib.h>
 */

--- a/v3/marquee.go
+++ b/v3/marquee.go
@@ -1,7 +1,6 @@
 package vlc
 
 /*
-#cgo LDFLAGS: -lvlc
 #include <vlc/vlc.h>
 #include <stdlib.h>
 */

--- a/v3/media.go
+++ b/v3/media.go
@@ -1,7 +1,6 @@
 package vlc
 
 /*
-#cgo LDFLAGS: -lvlc
 #include <vlc/vlc.h>
 #include <stdlib.h>
 #include <string.h>

--- a/v3/media_discoverer.go
+++ b/v3/media_discoverer.go
@@ -1,6 +1,5 @@
 package vlc
 
-// #cgo LDFLAGS: -lvlc
 // #include <vlc/vlc.h>
 // #include <stdlib.h>
 import "C"

--- a/v3/media_list.go
+++ b/v3/media_list.go
@@ -1,6 +1,5 @@
 package vlc
 
-// #cgo LDFLAGS: -lvlc
 // #include <vlc/vlc.h>
 import "C"
 import "io"

--- a/v3/media_track.go
+++ b/v3/media_track.go
@@ -1,6 +1,5 @@
 package vlc
 
-// #cgo LDFLAGS: -lvlc
 // #include <vlc/vlc.h>
 import "C"
 import (

--- a/v3/player.go
+++ b/v3/player.go
@@ -1,7 +1,6 @@
 package vlc
 
 /*
-#cgo LDFLAGS: -lvlc
 #include <vlc/vlc.h>
 #include <stdlib.h>
 */

--- a/v3/renderer.go
+++ b/v3/renderer.go
@@ -1,6 +1,5 @@
 package vlc
 
-// #cgo LDFLAGS: -lvlc
 // #include <vlc/vlc.h>
 import "C"
 

--- a/v3/renderer_discoverer.go
+++ b/v3/renderer_discoverer.go
@@ -1,6 +1,5 @@
 package vlc
 
-// #cgo LDFLAGS: -lvlc
 // #include <vlc/vlc.h>
 // #include <stdlib.h>
 import "C"

--- a/v3/utils.go
+++ b/v3/utils.go
@@ -1,6 +1,5 @@
 package vlc
 
-// #cgo LDFLAGS: -lvlc
 // #include <vlc/vlc.h>
 // #include <stdlib.h>
 import "C"

--- a/v3/version.go
+++ b/v3/version.go
@@ -1,6 +1,5 @@
 package vlc
 
-// #cgo LDFLAGS: -lvlc
 // #include <vlc/vlc.h>
 // #include <vlc/libvlc_version.h>
 import "C"

--- a/v3/vlc.go
+++ b/v3/vlc.go
@@ -1,6 +1,5 @@
 package vlc
 
-// #cgo LDFLAGS: -lvlc
 // #cgo CFLAGS: -w
 // #include <vlc/vlc.h>
 // #include <stdlib.h>


### PR DESCRIPTION
pkg-config is usually more aware of how exactly something should be linked, which may vary for different systems/environments.

To make the solution more universal using pkg-config instead of manual flag `-lvlc`.

Here is an example of another project which already uses this approach: https://github.com/asticode/go-astiav

More specifically, see: https://github.com/asticode/go-astiav/blob/cd2a16de95f911b69a9187708abe58d2c89b4390/astiav.go